### PR TITLE
Handle empty memberships list

### DIFF
--- a/custom_components/bibliotheek_be/utils.py
+++ b/custom_components/bibliotheek_be/utils.py
@@ -154,9 +154,13 @@ class ComponentSession(object):
         _LOGGER.debug(f"bibliotheek.be memberships get result status code: {responseMemberships.status_code}, response: {responseMemberships.text}")
         memberships = responseMemberships.json()
 
-        
         libraryDetails = {}
 
+        # Handle case where memberships can be an empty list or a dictionary
+        if isinstance(memberships, list):
+            _LOGGER.debug("Memberships is a list (likely empty), no accounts to process")
+            memberships = {}
+        
         for library_region_name, libraryRegionType in memberships.items():
             _LOGGER.debug(f"bibliotheek.be lidmaatschap library: {library_region_name}, libraryRegionType: {libraryRegionType}")
             libraryAccounts = libraryRegionType.get("library",libraryRegionType.get("region",None))


### PR DESCRIPTION
Hi,

Thanks a lot for the integration.
I've setup the integration before any memberships were linked to the account.
This caused an error since the API seems to return a list instead of a dictionary if there are no memberships:
```
2026-02-11 08:58:28.580 ERROR (MainThread) [bibliotheek_be] bibliotheek_be ComponentUpdateCoordinator update failed, username: xxx
Traceback (most recent call last):
  File "/config/custom_components/bibliotheek_be/coordinator.py", line 54, in _async_update_data
    self._userDetailsAndLoansAndReservations = await self._session.login(self._username, self._password)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/bibliotheek_be/utils.py", line 160, in login
    for library_region_name, libraryRegionType in memberships.items():
                                                  ^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'items'
```

This small PR fixes this issue and just assumes that if a list is returned it is most likely empty and just creates an empty dictionary.
I didn't find any info if this endpoint would ever return a list with data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of membership data to properly process edge cases and prevent iteration errors during account processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->